### PR TITLE
ignore double/single quote errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,5 @@
+
+# Ignore the double/single quote offenses
+StringLiterals:
+  Enabled: false
+


### PR DESCRIPTION
Ignores this offense, because _seriously_:
"Prefer single-quoted strings when you don't need string interpolation or special symbols."
